### PR TITLE
Better handling of already reSTed PEP

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,27 @@
 Script that converts text PEP into reST 
 
-result.rst is the converted PEP 243 using this script
-
-Usage::
+To convert a single text PEP::
 
    python3 restify_me.py /path/to/pep-xxx.txt
    
+
+To go through all PEPs in python/peps/ repo::
+
+   python3 collect_text_peps.py /path/to/peps/
+
+
+current output::
+
+   $ collect_text_peps.py ../peps/
+   Found 139 PEPs still in plain text
+   131 text PEPs converted :D
+   Failed to reSTify 8 PEPs :(
+   ../peps/pep-0100.txt because: string index out of range :(
+   ../peps/pep-0227.txt because: string index out of range :(
+   ../peps/pep-0236.txt because: string index out of range :(
+   ../peps/pep-0308.txt because: string index out of range :(
+   ../peps/pep-0324.txt because: string index out of range :(
+   ../peps/pep-0343.txt because: 'Local Variables:\n' is not in list :(
+   ../peps/pep-0344.txt because: string index out of range :(
+   ../peps/pep-3134.txt because: string index out of range :(
+

--- a/collect_text_peps.py
+++ b/collect_text_peps.py
@@ -1,0 +1,63 @@
+from argparse import ArgumentParser
+from restify_me import restify
+import glob, os
+
+
+def clear_output_dir():
+    """
+    remove output from previous run
+    """
+    files = glob.glob(os.path.join(os.getcwd(), 'output', 'pep-*.txt'))
+    for f in files:
+        os.remove(f)
+
+
+def text_peps(pep_repo_path):
+    """
+    return PEPs still in plain text
+    """
+    for filename in glob.glob(os.path.join(pep_repo_path, "pep-*.txt")):
+        with open(filename, 'r') as pep_file:
+            has_content_type = False
+            for line in pep_file.readlines():
+                if line.lower().startswith("Content-Type:".lower()):
+                    has_content_type = True
+                    if "text/plain" in line:
+                        yield filename
+            if not has_content_type:
+                yield filename
+
+
+def restify_text_peps(pep_repo_path):
+    """
+    1. find all plain text PEPs
+    2. restify
+    TODO:
+    3. run pep2html.py
+    4. open with webbrowser
+    """
+    failed = []
+    success = []
+    clear_output_dir()
+    for filename in text_peps(pep_repo_path):
+        try:
+            restify(filename)
+        except Exception as e:
+            failed.append((filename, e))
+
+        else:
+            success.append(filename)
+
+    print("Found {} PEPs still in plain text".format(len(failed) + len(success)))
+    print("{} text PEPs converted :D".format(len(success)))
+    print("Failed to reSTify {} PEPs :(".format(len(failed)))
+    for filename, error in failed:
+        print("{} because: {} :(".format(
+            filename, error))
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser(description="Collect plain text PEPs")
+    parser.add_argument("pep_path")
+    args = parser.parse_args()
+    restify_text_peps(args.pep_path)

--- a/restify_me.py
+++ b/restify_me.py
@@ -2,6 +2,36 @@ import os
 from argparse import ArgumentParser
 
 
+def can_restify(f):
+    """
+    decorator, proceed only if file can be reSTified
+    """
+    def wrapper(*args):
+        if args[0].restifiable:
+            return f(*args)
+    return wrapper
+
+
+def has_local_vars(f):
+    """
+    decorator, proceed only if file contains "Local vars:"
+    """
+    def wrapper(*args):
+        if args[0].has_local_vars_section:
+            return f(*args)
+    return wrapper
+
+
+def has_references(f):
+    """
+    decorator, proceed only if file contains "References"
+    """
+    def wrapper(*args):
+        if args[0].has_references_section:
+            return f(*args)
+    return wrapper
+
+
 class LineObj:
     """
     Represents a line in a PEP file
@@ -12,7 +42,7 @@ class LineObj:
 
     @property
     def indentation(self):
-        return len(self.line) - len(self.line.strip())
+        return len(self.line) - len(self.line.lstrip())
 
     @property
     def is_indented(self):
@@ -28,11 +58,11 @@ class LineObj:
 
     @property
     def is_pep_type_header(self):
-        return self.line.startswith("Type: ")
+        return self.line.lower().startswith("Type: ".lower())
 
     @property
     def is_content_type_header(self):
-        return self.line.startswith("Content-Type: ")
+        return self.line.lower().startswith("Content-Type: ".lower())
 
     @property
     def deindent(self):
@@ -45,7 +75,7 @@ class LineObj:
 
     @property
     def is_local_vars(self):
-        return self.line == 'Local Variables:'
+        return self.line.strip().lower() == 'Local Variables:'.lower()
 
     @property
     def is_literal_block(self):
@@ -78,7 +108,7 @@ class LineObj:
 def is_section_heading(current_line, prev_line, next_line):
     """
     Detects first level section heading, which is
-    A line that has empty line before and after is a section heading
+    a line that has empty line before and after
     """
     return (
         not current_line.is_blank
@@ -97,6 +127,14 @@ def is_missing_content_type_header(current_line, prev_line):
         and not current_line.is_content_type_header
 
 
+class ConversionNotRequiredError(Exception):
+    """
+    Raised when PEP is already in text/x-rst format
+    """
+    def __init__(self, filename):
+        self.message = "{} is already in text/x-rst format.".format(filename)
+
+
 class TextToRest:
     """
     Read a text file and attempt to convert it to reST
@@ -105,8 +143,10 @@ class TextToRest:
 
     output = []
     all_lines = []
-
+    has_references_section = False
+    has_local_vars_section = False
     is_references_section = False
+    restifiable = True
 
     references = []
 
@@ -116,16 +156,16 @@ class TextToRest:
         self.path = path
         with open(self.path, 'r') as file:
             self.all_lines = file.readlines()
-        if "Content-Type: text/x-rst\n" in self.all_lines:
-            raise Exception("All is good!")
+        if "Content-Type: text/x-rst\n".lower() in \
+                map(lambda x: x.lower(), self.all_lines):
+            self.restifiable = False
+            raise ConversionNotRequiredError(path)
 
+    @can_restify
     def handle_content_type_header(self, current_line, prev_line):
         """
         if content type is missing, add it
         if content type is present, ensure it is rst
-        :param current_line:
-        :param prev_line:
-        :return:
         """
         if current_line.is_content_type_header:
             # ensure it is reST
@@ -138,6 +178,8 @@ class TextToRest:
             self.output.append("Content-Type: text/x-rst")
             self.output.append(os.linesep)
 
+    @can_restify
+    @has_local_vars
     def process_local_vars(self):
         """ take care of Local variables at the end of PEP """
         local_vars = self.all_lines[
@@ -147,6 +189,8 @@ class TextToRest:
         for line in local_vars:
             self.output.append("  {}".format(line))
 
+    @can_restify
+    @has_references
     def process_reference_line(self, line_obj):
         stripped_text = line_obj.output.strip()
         if line_obj.is_blank:
@@ -167,17 +211,18 @@ class TextToRest:
                     stripped_text))
             self.output.append(os.linesep)
 
+    @can_restify
     def handle_paragraph(self, line_obj):
         if line_obj.is_indented:
             self.output.append(line_obj.deindent)
         else:
             self.output.append(line_obj.output)
 
+    @can_restify
     def convert(self):
         """
-        read all lines in file, and process them one by one
+        enumerate through all lines and process them one by one
         """
-
         for index, line in enumerate(self.all_lines):
             if index == 0:
                 # this is the first line of the file, eg PEP: XXX header
@@ -205,14 +250,17 @@ class TextToRest:
                     self.output.append(
                         current_line_obj.section_header_underline)
                     self.output.append(os.linesep)
-                    if stripped == "References":
+
+                    if stripped.lower() == "References".lower():
                         self.is_references_section = True
+                        self.has_references_section = True
                     elif self.is_references_section:
                         # we were in references section, and now moved on
                         self.is_references_section = False
                         self.last_ref_id = ""
 
                 elif current_line_obj.is_local_vars:
+                    self.has_local_vars_section = True
                     return
 
                 else:
@@ -223,6 +271,8 @@ class TextToRest:
                             current_line_obj
                         )
 
+    @can_restify
+    @has_references
     def link_references(self):
         """
         go through everything one more time, updating links to references
@@ -231,11 +281,13 @@ class TextToRest:
         into
             [1]_
         """
-        ref_section_index = self.output.index("References")
+        ref_section_index = [out.lower() for out in self.output].index(
+            "References".lower())
         for index, line in enumerate(self.output):
             for ref in self.references:
                 potential_ref_link = "[{}]".format(ref)
-                if potential_ref_link in line and index < ref_section_index:
+                if potential_ref_link in line \
+                        and index < ref_section_index:
                     line = line.replace(
                         potential_ref_link,
                         "{}_".format(potential_ref_link))
@@ -256,8 +308,10 @@ if __name__ == '__main__':
     args = parser.parse_args()
     try:
         text_to_rest = TextToRest(args.filename)
-    except:
-        print("PEP is already in reST")
+    except ConversionNotRequiredError as err:
+        print(err.message)
+    except FileNotFoundError:
+        print("File {} is not found.".format(args.filename))
     else:
         text_to_rest.convert()
         text_to_rest.process_local_vars()


### PR DESCRIPTION
- create custom exception for when PEP is already in reST format
- add decorators, so conversion won't happen
   unless certain conditions are satisfied
- handle case when file not found
- ignore case when checking PEP headers

#3 

@gvanrossum I addressed some of your feedback. Thanks :)
