### PR TITLE
try to replace inline literals

### DIFF
--- a/inline-literals.txt
+++ b/inline-literals.txt
@@ -5,3 +5,4 @@ divmod(x)
 divmod(x, *divs)
 divmod(dividend, *divisors)
 divmod(dividend, divisor)
+TypeError

--- a/inline-literals.txt
+++ b/inline-literals.txt
@@ -1,0 +1,7 @@
+divmod()
+__builtin__
+divmod("spam")
+divmod(x)
+divmod(x, *divs)
+divmod(dividend, *divisors)
+divmod(dividend, divisor)

--- a/inline-literals.txt
+++ b/inline-literals.txt
@@ -9,3 +9,12 @@ TypeError
 ProcessIOWrapper
 asyncread
 asyncwrite
+strftime()
+str(value)
+ValueError
+__format__
+len()
+str()
+locals()
+Python/bltinmodule.c
+builtin_divmod()

--- a/inline-literals.txt
+++ b/inline-literals.txt
@@ -6,3 +6,6 @@ divmod(x, *divs)
 divmod(dividend, *divisors)
 divmod(dividend, divisor)
 TypeError
+ProcessIOWrapper
+asyncread
+asyncwrite

--- a/restify_me.py
+++ b/restify_me.py
@@ -21,6 +21,9 @@ PEP_HEADERS = [
     "Resolution"
 ]
 
+INLINE_LITERALS = []
+with open("./inline-literals.txt") as file:
+    INLINE_LITERALS = [line.strip() for line in file.readlines()]
 
 class LineObj:
     """
@@ -78,11 +81,15 @@ class LineObj:
 
     @property
     def output(self):
-        if not self.is_code_block \
-                and "*" in self.line \
+        if not self.is_code_block:
+            if "*" in self.line \
                 and self.line.count("*") == 1 \
                 and self.line[self.line.index("*") + 1] != " ":
-            self.line = self.line.replace("*", "\*")
+                self.line = self.line.replace("*", "\*")
+            for inline_literal in INLINE_LITERALS:
+                if inline_literal in self.line and not self.is_pep_header:
+                    self.line = self.line.replace(
+                        inline_literal, "``{}``".format(inline_literal))
 
         if self.ends_with_colon \
                 and not self.is_pep_header \
@@ -109,7 +116,7 @@ class LineObj:
         returns True if line is a PEP header
         """
         stripped = self.line.lstrip()
-        if stripped.index(":") > 0:
+        if ":" in stripped and stripped.index(":") > 0:
             text = stripped[:stripped.index(':')]
             if text in PEP_HEADERS:
                 return True


### PR DESCRIPTION
Create a list of known inline literals
Try to replace them, for example from divmod() into ``divmod()``

Just going through examples in PEP 303 for now.